### PR TITLE
RELENG-2330 Replace the legacy /repo prefix the Artifactory URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	License file at legal/CDDLv1.0.txt. If applicable, add the following below 
 	the CDDL * Header, with the fields enclosed by brackets [] replaced by your 
 	own identifying * information: "Portions copyright [year] [name of copyright 
-	owner]". * * Copyright 2017-2018 ForgeRock AS. * -->
+	owner]". * * Copyright 2017-2023 ForgeRock AS. * -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -104,7 +104,7 @@
 			</snapshots>
 			<id>forgerock-private-releases</id>
 			<name>ForgeRock Private Release Repository</name>
-			<url>http://maven.forgerock.org/repo/private-releases</url>
+			<url>https://maven.forgerock.org/artifactory/private-releases</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Hi,
The ForgeRock Artifactory instance will soon move to the JFrog.io SaaS.
The URL will remain the same but the /repo prefix won't work anymore.
Thanks,
Bruno Lavit, release manager at ForgeRock